### PR TITLE
29-fix-large-images

### DIFF
--- a/pages/habilidades.html
+++ b/pages/habilidades.html
@@ -31,50 +31,50 @@
 
       <div class="skills-cards-grid">
         <div class="skill-card">
-          <img class="profile-img" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/html5/html5-original.svg" alt="HTML">
+          <img class="skill-icon" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/html5/html5-original.svg" alt="HTML">
           <h4 class="card-title">HTML</h4>
         </div>
 
         <div class="skill-card">
-          <img class="profile-img" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/css3/css3-original.svg" alt="CSS">
+          <img class="skill-icon" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/css3/css3-original.svg" alt="CSS">
           <h4 class="card-title">CSS</h4>
         </div>
 
         <div class="skill-card">
-          <img class="profile-img" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg" alt="JavaScript">
+          <img class="skill-icon" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg" alt="JavaScript">
           <h4 class="card-title">JavaScript</h4>
         </div>
 
         <div class="skill-card">
-          <img class="profile-img" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/wordpress/wordpress-plain.svg" alt="WordPress">
+          <img class="skill-icon" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/wordpress/wordpress-plain.svg" alt="WordPress">
           <h4 class="card-title">WordPress</h4>
         </div>
 
         <div class="skill-card">
-          <img class="profile-img" src="https://cdn-icons-png.flaticon.com/512/4248/4248443.png" alt="Bases de datos">
+          <img class="skill-icon" src="https://cdn-icons-png.flaticon.com/512/4248/4248443.png" alt="Bases de datos">
           <h4 class="card-title">Bases de datos</h4>
         </div>
 
         <div class="skill-card">
-          <img class="profile-img" src="https://cdn-icons-png.flaticon.com/512/3064/3064197.png" alt="Ciberseguridad">
+          <img class="skill-icon" src="https://cdn-icons-png.flaticon.com/512/3064/3064197.png" alt="Ciberseguridad">
           <h4 class="card-title">Ciberseguridad</h4>
         </div>
 
         <div class="skill-card">
-          <img class="profile-img" src="https://cdn-icons-png.flaticon.com/512/2920/2920244.png" alt="Soporte IT">
+          <img class="skill-icon" src="https://cdn-icons-png.flaticon.com/512/2920/2920244.png" alt="Soporte IT">
           <h4 class="card-title">Soporte IT</h4>
         </div>
 
         <div class="skill-card">
-          <img class="profile-img" src="https://cdn-icons-png.flaticon.com/512/4144/4144783.png" alt="Hosting">
+          <img class="skill-icon" src="https://cdn-icons-png.flaticon.com/512/4144/4144783.png" alt="Hosting">
           <h4 class="card-title">Hosting</h4>
         </div>
         <div class="skill-card">
-          <img class="profile-img" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/github/github-original.svg" alt="GitHub">
+          <img class="skill-icon" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/github/github-original.svg" alt="GitHub">
           <h4 class="card-title">GitHub</h4>
         </div>
         <div class="skill-card">
-          <img class="profile-img" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/gitlab/gitlab-original.svg" alt="GitLab">
+          <img class="skill-icon" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/gitlab/gitlab-original.svg" alt="GitLab">
           <h4 class="card-title">GitLab</h4>
         </div>
       </div>


### PR DESCRIPTION
Se corrigió el tamaño excesivo de las imágenes en la sección de habilidades reemplazando la clase incorrecta profile-img por skill-icon.
Asi mismo se supone que tomarían el tamaño correcto de icono